### PR TITLE
resolve pip install requirements issues with spacy/spacy-readability

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ To install the required Python 3 packages use:
 
 ```bash
 pip3 install -r requirements.txt
+pip3 install --upgrade spacy
+pip3 install pytextrank
 ```
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
-spacy>=3.3.0
+spacy<3.0
 spacy-legacy==3.0.9
 spacy_readability>=1.4.1
-pytextrank>=3.2.0
 networkx>=2.8.0
 pandas>=1.4
 nltk>=3.7


### PR DESCRIPTION
It is not ideal, but first installing spacy 2 with spacy readability, and then upgrading spacy and installing pytextrank is a workaround for the conflicting dependencies. I submitted an issue to spacy readability to ask them to make the package compatible with spacy 3