### PR TITLE
add markdown link check yml

### DIFF
--- a/.github/workflows/markdown-link-check.yml
+++ b/.github/workflows/markdown-link-check.yml
@@ -1,0 +1,18 @@
+name: markdown-link-check
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+
+  markdown-link-check:
+    name: Check markdown links
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@main
+    - uses: gaurav-nelson/github-action-markdown-link-check@v1
+      with:
+        config-file: '.mlc-config.json'


### PR DESCRIPTION
This PR adds a markdown link checker GitHub action to the workflows. The action will check if all links in the markdown files still work when something is pushed to the main branch